### PR TITLE
22 - Requirements to publish on NPM 

### DIFF
--- a/general-instruction-npm.md
+++ b/general-instruction-npm.md
@@ -1,63 +1,34 @@
 <div id="top"></div>
 
-# Publishing npm Packages with the Public npm Registry
+# Package Management with npm
 
-> npm is the world's largest software registry. Open source developers from every continent use npm to share and borrow packages, and many organizations use npm to manage private development...
+> npm is the world's largest software registry. Open source developers from every continent use npm to share and borrow packages, and many organizations use npm to manage private development
 
-Step-by-Step Guide for Publishing npm Packages to the Public npm Registry.
+:link: [npm Docs](https://docs.npmjs.com)
 
-**Resources:**<br/>
+Step-by-Step Guide for publishing and managing npm packages to the [public npm registry](https://docs.npmjs.com/about-the-public-npm-registry).
 
-:link: [npm Docs](https://docs.npmjs.com)<br />
-:link: [Git Docs](https://git-scm.com/doc)<br />
-:link: [Github Docs](https://docs.github.com)<br />
-:link: [GithubCLI Docs](https://cli.github.com)
+**NOTE:** [Node.js](https://nodejs.org/en/) and the [npm CLI](https://docs.npmjs.com/cli/v8/configuring-npm/install) are required.
 
-<details>
-<summary><h4>Table of Contents</h4></summary>
+## Table of Contents
 
-[Prerequisite]()
+[Step 1: Setup npm Accounts]()
 
-[Step 1: Setting up npm Accounts]()
+- [&#10102; Create npm User Accounts]()
+- [&#10103; Register an Organization]()
+- [&#10104; Manage Teams and Members]()
 
-- [&#10112; Register npm User Accounts]()
-- [&#10113; Create an Organization]()
-- [&#10114; Manage Organization Teams and Members]()
-
-[Step 2: Developing a npm Package]()
-
-- [&#10112; Access to a npm User Account]()
-- [&#10113; Manage npmrc Configuration files]()
-- [&#10114; Test a npm Package Locally]()
-
-[Step 3: Publishing a Package to npm Registory]()
+[Step 2: Register a npm Package]()
 
 - [Option 1 &horbar; Using command line]()
-- [Option 2 &horbar; Using Github Actions]()
+- [Option 2 &horbar; Using Github Actions workflows]()
 
-[Step 4: Managing a npm Package with Github Actions]()
+[Step 3: Manage the npm Package]()
 
-</details>
+- [&#10102; Test a npm Package Locally]()
+- [&#10103; Release a new version]()
 
-<details>
-<summary><h2>Prerequisite</h2></summary>
-
-[Node.js](https://nodejs.org/en/) and the [npm CLI](https://docs.npmjs.com/cli/v8) are required to use the public npm registry.
-
-The following command will outputs the Node.js and npm version numbers if its installed on the machine:
-
-```
-node -v && npm -v
-```
-
-(For more information: [Install](https://docs.npmjs.com/cli/v8/configuring-npm/install))
-
-<p align="right">(<a href="#top">back to top</a>)</p>  
-  
---- 
-</details>
-
-## Step &#10102; Setting Up npm Accounts
+## Step 1: Setup npm Accounts
 
 **(Basic Terminologie)**
 
@@ -65,172 +36,29 @@ node -v && npm -v
 <summary>&horbar; Information to get started</summary>
 
 We need to prepare the following information prior to signing up for a new npm account.
-
-<table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Value</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Username <br/><sup>(Required)</sup></td>
-      <td>All lowercase letters and can contains digits and hyphens</td>
-    </tr>
-    <tr>
-      <td>Email Address<br/><sup>(Required)</sup></td>
-      <td>Registered email address is <strong>public</strong> and it'll be:
-        <ul>
-            <li>added to the metadata of our packages and visible to anyone who downloads them.</li>
-            <li>used by npm for email notifications</li>
-        </ul>
-     </td>
-    </tr>
-    <tr>
-      <td>Password <br/><sup>(Required)</sup></td>
-      <td>At least 10 characters(with <a href="https://www.lastpass.com">Lastpass</a> and requires<a href="https://docs.npmjs.com/configuring-two-factor-authentication">2FA</a>)<br/>
-      (For more information: <a href="https://docs.npmjs.com/creating-a-strong-password">Creating a strong password</a>)  
-      </td>
-    </tr>
-    <tr>
-      <td>Orgniazation Name <br/><sup>(Required)</sup></td>
-      <td>All lowercase letters and can contains digits and hyphens<br/>(*This value cannot be the same as a username)</td>
-      </td>
-    </tr>
-      <td>Billing Information<br/><sup>(Optional)</sup></td>
-      <td>A paid account to publish private packages
-      </td>
-    </tr>
-  </tbody>
-</table>
+|Field|Value|
+|---|---|
+|Username<br/><sup>(Required)</sup>|All lowercase letters and can contains digits and hyphens|  
+|Email Address<br/><sup>(Required)</sup>|Registered email address is **public** and it'll be:<br /> - added to the metadata of our packages.<br/>- visible to anyone who downloads our package.<br/>- used by npm for email notifications|
+|Password<br/><sup>(Required)</sup>|At least 10 characters with [Lastpass](https://www.lastpass.com) and is required [2FA](https://docs.npmjs.com/configuring-two-factor-authentication) configuration with Yubikey.<br/>(For more information: [Creating a strong password](https://docs.npmjs.com/creating-a-strong-password))|
+|Orgniazation Name<br/><sup>(Required)</sup>|All lowercase letters and can contains digits and hyphens.It cannot be the same as the `Username`|  
+|Billing Information<br/><sup>(Optional)</sup>|It required for [paid accounts](https://www.npmjs.com/products) and for using [private packages](https://docs.npmjs.com/about-private-packages)|
 
 ---
 
 </details>
 
 <details>
-<summary>&horbar; npm account types</summary>
-  
-npm offers a **free** account as well as a [monthly **paid** subscription](https://www.npmjs.com/products).
-<table>
-  <thead>
-    <tr>
-      <th>Free</th>
-      <th><sup>For individuals</sup><br/>Pro<br/><sup>($7 per /mo)</sup></th>
-      <th><sup>For teams / organizations</sup><br/>Team<br/><sup>($7 per user /mo)</sup></th>
-      <th>Feature</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td align="center">&#10003;</td>
-      <td align="center">&#10003;</td>
-      <td align="center">&#10003;</td>
-      <td><strong>Unlimited Public Packages</strong> & Automatic Security Warnings</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td align="center">&#10003;</td>
-      <td align="center">&#10003;</td>
-      <td><strong>Unlimited private packages</strong> & Unlimited Package-based Permissions</td>
-    </tr>
-    <tr>
-      <td></td>
-      <td></td>
-      <td align="center">&#10003;</td>
-      <td>Unlimited Team-based Permissons and Management</td>
-    </tr>     
-  </tbody>
-</table>
-    
---- 
-</details>
-
-<details>
-<summary>&horbar; npm registries</summary>
-
-There are **public** and **private npm registries** available to publish npm packages.
-
-<table>
-  <thead>
-    <tr>
-      <th>Type</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><a href="https://docs.npmjs.com/about-the-public-npm-registry">public npm registry</a></td>
-      <td> 
-        The default registry<br/>
-        <ul>
-          <li>Publish public packages</li>
-          <li>Registry URL https://registry.npmjs.org</li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td><a href="https://docs.npmjs.com/cli/v8/using-npm/registry#how-can-i-prevent-my-package-from-being-published-in-the-official-registry">private npm registry</a></td>
-      <td>
-        The private registry/proxy to:
-        <ul>
-          <li>Publish private packages</li>
-          <li>Set up better security control</li>
-          <li>Encapsulate business logic</li>
-        </ul>
-        Popular options include:<br/>
-        <strong>Open source:</strong> <a href="https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry"><strong>Github Packages(recommended)</strong></a>, <a href="https://verdaccio.org">Verdaccio</a>, <a href="https://bit.dev">Bit</a><br/>
-        <strong>Paid:</strong> <a href="https://www.npmjs.com/products">npm monthly subscription</a>, <a href="https://www.jfrog.com">Frog Bintray</a>, <a href="https://docs.myget.org">MyGet</a>    
-      </td>
-    </tr>
-  </tbody>
-</table>
-  
-(For more information: [Registry](https://docs.npmjs.com/cli/v8/using-npm/registry))  
-  
----  
-</details>
-
-<details>
 <summary>&horbar; Package visibility and scopes</summary>
   
->   Unscoped packages are always public. Private packages are always scoped. Scoped packages are private by default;...
-  
-We'll be publishing and managing the **organization scoped packages**. An organization sopced package are private by defailt. Thus, to publish our packages to the public npm registry, we'll need to explicitely set thier visibility to **public** upon publishing.
-  
-<table>
-  <thead>
-    <tr>
-      <th>Visibility</th>
-      <th>Namespace</th>
-      <th>Cost</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td align="center">Public</td>
-      <td align="center">global,<br/>User,<br/><strong>Organization</strong></td>
-      <td align="center">Free</td>
-      <td>
-        A <a href="https://docs.npmjs.com/about-public-packages">public package</a> may be unscoped or scoped and is visible to everyone.
-        <ul>
-          <li>Unscoped public packages belong to the global public registry namespace</li>
-          <li>Scoped public packages belong to a user or an organization namespace</li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
-      <td align="center">Private</td>
-      <td align="center">User,<br/><strong>Organization</strong></td>
-      <td align="center">Monthly Paid Subscription</td>
-      <td>A <a href="https://docs.npmjs.com/about-private-packages">private package</a> belongs to a user or an organization namespace and is only visible to its account owner and its organization and selected collaborators.<br/> 
-      </td>
-    </tr>
-  </tbody>
-</table>
-  
+> Unscoped packages are always public. Private packages are always scoped. Scoped packages are private by default;
+
+We'll be publishing and managing the **scoped public packages**. An organization sopced package are private by defailt. Thus, to publish our packages to the npm registry, we'll need to explicitely set thier visibility to **public**.
+|Visibility|Namespace|Cost||
+|:---:|:---:|:---:|---|  
+|Public|global,<br/>User,<br/>**Organization**|Free| A [public package](https://docs.npmjs.com/about-public-packages) may be unscoped or scoped and is visible to everyone.<br/>- Unscoped public packages belong to the global public registry namespace<br/>- Scoped public packages belong to a user or an organization namespace|
+|Private|User,<br/>**Organization**|Monthly Paid Subscription|A [private package](https://docs.npmjs.com/about-private-packages) belongs to a user or an organization namespace and is only visible to its account owner and its organization and selected collaborators.|
+
 (For more information: [About scopes](https://docs.npmjs.com/about-scopes), [Packages scope access level and visibility](https://docs.npmjs.com/package-scope-access-level-and-visibility))
 
 ---
@@ -239,13 +67,15 @@ We'll be publishing and managing the **organization scoped packages**. An organi
 
 <details>
 <summary>&horbar; Organizational user roles</summary>
-  
+
+Each role can be assigned to multiple users, whereas a single user cannot have multiple roles.
+
 There are three organizational user roles:
 |Role|Permisson|
 |:---:|---|
-|Owner|who have all privileges and are responsible for managing organization members and billing|
-|Admin|who are responsible for managing the team membership and package access|
-|Member|who are merely responsible for creating and publishing packages|
+|Owner|who has all privileges and are responsible for managing organization members and billing|
+|Admin|who is responsible for managing the team membership and package access|
+|Member|who is merely responsible for creating and publishing packages|
 
 (For more information: [Organization roles and permissions](https://docs.npmjs.com/organization-roles-and-permissions))
 
@@ -253,147 +83,107 @@ There are three organizational user roles:
 
 </details>
 
+### &#10102; Create npm User Accounts
+
+:link: [Creating a new user account on the public registry](https://docs.npmjs.com/creating-a-new-npm-user-account)
+
+#### 1 ) Create the CCDL User Account for an Organization
+
+Once the organization is created(i.e. an **Organization Name** will be added to this account), this account will be;
+
+- an **Owner user**(non-reassignable).
+- automatically added as a member of the default team [**developers**](https://docs.npmjs.com/about-developers-team) which is irremovable.
+
+(For this CCDL account, the **Username** named as `ccdl-npm`.)
+
+#### 2 ) Create User Accounts for Collaborators
+
+**Username**
+: should be a Github contributor's username of our repository.<br/>
+**Email Address**
+: should be either an email address associated with the above Github account or `<name>@ccdatalab.org`
+
+Each account will be used for either;
+
+- an **Owner user** who manages the organizational tasks including bullings
+- an **Admin user** who manages team and package access in the organization.
+- a **Member user** who creates and publishes packages within the organizational scope.
+
+### &#10103; Register an Organization
+
+Depending on the needs, there are two ways in which we can create an organization.
+
 <details>
-<summary><h3>&#10112; Register npm User Accounts</h3></summary>
-  
-  :link: [Creating a new user account on the public registry](https://docs.npmjs.com/creating-a-new-npm-user-account)
-    
-  **1 ) Create the CCDL User Account**
-  
-  This account will be used for creating an organiazation in the next step [&#10113; Create an Organization]().
-  
-  An email address used for this account is public facing and will be **visible** to anyone who downloads our packages.
-  
-  Once the organization is created, this account will be; 
-  - converted to an **organization**(i.e. an **Organization Name** will be added to this account).
-  - an **Owner user**(non-reassignable).
-  - automatically added as a member of a team [**developers**](https://docs.npmjs.com/about-developers-team)
-  
-  e.g.)
-  
-  <strong>Username</strong>
-  : ccdl-npm, ccdl-master, ccdl-super 
-  
-  <strong>Email Address</strong>
-  : ccdl-npm@ccdatalab.org, npm@ccdatalab.org 
- 
-  <br/>
-  
-  
-  **2 ) Create User Accounts for Collaborators**
-  
-  Each account will be used for either; 
-  - an **Owner user** who manages the organizational tasks including bullings
-  - an **Admin user** who manages team and package access in the organization.
-  - a **Member user** who creates and publishes packages within the organizational scope.
-  
-  e.g.)
-  
-   <strong>Username</strong>
-  : a Github contributor's username of our repository
-  
-   <strong>Email Address</strong>
-  : an email address associated with the above Github account
+<summary><strong>Option 1 &horbar; Add an organization to a newly created user account</strong></summary>
 
----
+:link: [Create an Organization](https://docs.npmjs.com/creating-an-organization)
 
-</details>
-  
-<details>
-<summary><h3>&#10113; Create an Organization</h3></summary>
-   
-  Depending on the needs, there are two ways in which we can create an organization.
-  
-  <details>
-  <summary><strong>Option 1 &horbar; Add an organization to a newly created user account</strong></summary>
-      
-  :link: [Create an Organization](https://docs.npmjs.com/creating-an-organization)
-  
-  **1 ) Add an Organization Name to the CCDL user account**
- 
-  The Organization Name;
-  - cannot be the same as the **Username** of this CCDL account.  
-  - cannot be changed once it's created.
-  - will be used as an <strong>organizational scope</strong>.
+#### 1 ) Add an Organization to the CCDL user account
 
-  <br/>  
-    
-  **2 ) Select an Account Plan**
-  
-  If publishing only scoped **public** packages with a minimal team management, then a **free** account will be sufficient. Otherwise, the **Team** product would be suitable.
+The Organization Name;
+
+- cannot be changed once it's created.
+- will be used as an <strong>organizational scope</strong>.
+
+(For this CCDL account, the **Orgnization Name** named as `ccdl`.)
+
+#### 2 ) Select an Account Plan
+
+A **free** account will be sufficient, if publishing only scoped **public** packages with a minimal team management. Otherwise, the **Team** product would be suitable.
 
 **NOTE:** The account plan can be [upgraded](https://docs.npmjs.com/upgrading-to-a-paid-organization-plan) or [downgraded](https://docs.npmjs.com/downgrading-to-a-free-organization-plan) at anytime.
 
-  <br/>  
-    
-  **3 ) Invite Members <sup>(optional)</sup>**
-   
-  We can invite a person to be a member of our organization using an existing **npm username** or an **email adress**(it can also be a non-npm email address and npm will ask the invitee to signup). The invitation will be sent out via an email which expires in 7 days and is revokable.
-   
-  Once the invitation has been accepted, we can reassign a different role or a team to that newly added member. 
-    
-  - A single user can belong to multiple teams or no team. 
-  - Each role can be assigned to multiple users, whereas a single user cannot have multiple roles.  
-    
-  **IMPORTANT:** For the paid organization, adding a new member costs $7 per /mo for each new member.
+#### 3 ) Invite Members <sup>(optional)</sup>\*\*
+
+We can invite a person to be a member of our organization using an existing **npm username** or an **email adress**(it can also be a non-npm email address). The invitation will be sent out via an email which is revokable and expires in 7 days.
+
+Once the invitation has been accepted, we can reassign a different role or a team to that newly added member.
+
+- A single user can belong to multiple teams or no team.
+- Each role can be assigned to multiple users, whereas a single user cannot have multiple roles.
+
+**IMPORTANT:** For the paid organization, adding a new member costs $7 per /mo for each new member.
 
 ---
 
-  </details>
+</details>
   
-  <details>
-  <summary><strong>Option 2 &horbar; Converting an already exsisting user account to an organization</strong></summary>
+<details>
+<summary><strong>Option 2 &horbar; Converting an already exsisting user account to an organization</strong></summary>
   
-  :link: [Converting your user account to an organization](https://docs.npmjs.com/converting-your-user-account-to-an-organization)
+:link: [Converting your user account to an organization](https://docs.npmjs.com/converting-your-user-account-to-an-organization)
 
 The steps will be similar to **Option 1** except we'll need to come up with a new **Username** for this exsisting account, since this **Username** will be now used as an **Organization Name**.
 
-**NOTE:** A **Username** and an **Organization Name** cannot have the same value.
-
----
-
-  </details>
 </details>
 
+### &#10104; Manage Teams and Members
+
+Managing teams and memberships in the orgnization can be done using the web or the npm CLI.
+
+**Note:** A user must be **Admin user** to manage teams and packages.
+
 <details>
-<summary><h3>&#10114; Manage Organization Teams and Members</h3></summary>
-  
-Managing teams and memberships can be done using the web interface or the npm CLI. 
-  
-**Note:** A user must be **Admin user** to manage teams and packages.  
-  
-<details>
-<summary><strong>Option 1 &horbar; Using Web Interface</strong></summary><br/>
+<summary><strong>Option 1 &horbar; Using web interface</strong></summary><br/>
       
 **&#10074; Managing Members**
   
-- [Add Members](https://docs.npmjs.com/adding-members-to-your-organization)
-  
-- [Managing User Permission](https://docs.npmjs.com/managing-organization-permissions)
-  
+- [Add Members](https://docs.npmjs.com/adding-members-to-your-organization) 
+- [Managing User Permission](https://docs.npmjs.com/managing-organization-permissions) 
 - [Remove Members](https://docs.npmjs.com/removing-members-from-your-organization)
   
 <br/>  
   
 **&#10074; Managing Teams** 
   
-We can create and manage our custom teams:
-  
+We can create and manage our custom teams: 
 - [Creating Teams](https://docs.npmjs.com/creating-teams)
-  
 - [Removing Teams](https://docs.npmjs.com/removing-teams)  
-  
 - [Adding Team Memmbers](https://docs.npmjs.com/adding-organization-members-to-teams) 
-  
 - [Removing Team Members](https://docs.npmjs.com/removing-organization-members-from-teams)  
- 
 - [Managing Team Access to Packages](https://docs.npmjs.com/managing-team-access-to-organization-packages)
-  
-<br/>  
-  
-**NOTE:** By default, the team [**developers**](https://docs.npmjs.com/about-developers-team) is automatically created with read/write access upon the creation of an organization and is nonremovable.   
-  
----  
+ 
+--- 
 </details>
 
 <details>
@@ -401,14 +191,13 @@ We can create and manage our custom teams:
 
 By using [`npm team`](https://docs.npmjs.com/cli/v8/commands/npm-team) command, we can manage teams. However, no support for managing package permissions.
 
-</details> 
 </details>
 
 <p align="right">(<a href="#top">back to top</a>)</p>
 
 ---
 
-## Step &#10103; Developing a npm Package
+## Step 2: Register a npm Package
 
 **(Basic Terminologie)**
 
@@ -441,8 +230,6 @@ An [access token](https://docs.npmjs.com/about-access-tokens)(a hexadecimal stri
 
 The npm CLI will auto-generate an temporary access token upon running the [`npm login`](https://docs.npmjs.com/cli/v8/commands/npm-adduser) command or we can [create our custom access token](https://docs.npmjs.com/creating-and-viewing-access-tokens) to privde a third-party temporary access to our npm packages.
 
-e.g.) [Github Actions](https://docs.github.com/en/actions) using [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
-
 There is three token types:
 |Type|Permisson|  
 |---|---|
@@ -453,24 +240,6 @@ There is three token types:
 ---
 
 </details>
-
-<details>  
-<summary>&horbar; npm Package naming</summary>
- 
-A package name must;
-- be lowercase and my contain hyphens
-- be greater than zeroand less than or equal to 214 characters  
-- not contain any non-URL-safe characters
-- not start with . or _ unless it's a scoped package
-- not contain any spaces  
-- not contain `~)('!*` characters
-- not be the same as a node.js/io.js core module or a reserved/blacklisted name
-
-(For more information: [npm Package name guidelines](https://docs.npmjs.com/package-name-guidelines), [validate-npm-package-name](https://www.npmjs.com/package/validate-npm-package-name), [name field in package.json](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#name))
-
----
-
-</details>  
   
 <details>
 <summary>&horbar; Semantic Versioning(SemVar)</summary>
@@ -518,6 +287,16 @@ e.g.) 1.0.0-alpha, 1.0.0-alpha.1, 1.0.0-0.3.7, 1.0.0-x.7.z.92, 1.0.0-x-y-z.–.
 
 </details>
 
+### Preparation
+
+> Registry data is immutable, ...once published, a package cannot change.
+
+Before registering our local package to [the public npm registory](https://docs.npmjs.com/about-the-public-npm-registry), make sure that;
+
+- all the configuration files are setup correctly.
+- no credentials or any other sensitive information is included in an installable.
+- a package is tested locally and bug free.
+
 <details>
 <summary>&horbar; package.json</summary>
 
@@ -546,19 +325,18 @@ To setup a package.json for the npm package, the following fields should be incl
 
 e.g.)
 
-```
+```json
 {
   "name": "@scope/pakage-name",
   "version": "1.0.0",
   "description": "A package for ....",
   "main": "index.js",
-  "script": { ... },
-  "dependencies" :  {...},
+  "script": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/socope/pakage-name.git"
   },
-  "keywords": [‘keyword1’, 'keyword2', 'keyword3'],
+  "keywords": ["keyword1", "keyword2", "keyword3"],
   "contributors" : [
     {
        "name": "contributors1",
@@ -578,10 +356,8 @@ e.g.)
 
 (For more information: [Creating a package.json file](https://docs.npmjs.com/creating-a-package-json-file), [package.json](https://docs.npmjs.com/cli/v8/configuring-npm/package-json))
 
----
+</details>
 
-</details>    
-  
 <details>
 <summary>&horbar; README.md</summary>
 
@@ -614,186 +390,341 @@ To add a LICENSE file can be easily done via Github Web Interface:
 
 ---
 
+</details>  
 </details>
 
 <details>
-<summary><h3>&#10112; Access to a npm User Account</h3></summary>
-   
-We can access to the registered npm account from a local device using the npm CLI.
+<summary><h4>Option 1 &horbar; Using command line</h4></summary>
 
-**&#10074; Login to npm**
+### &#10102; Access an npm Account
 
-**1 )** Run the [`login`](https://docs.npmjs.com/cli/v8/commands/npm-adduser)(aliases: `adduser`) command. To specify an organization scope, use `--scope` flag:
+**IMPORTANT:** Never use the CCDL account to release or update a package, but rather use the accounts of individual members.
 
-- `OWNER` - the name of a user or an organization of the repository containing the project
+#### &#10074; Login
+
+**1 )** Navigate to the local package and run the [`npm login`](https://docs.npmjs.com/cli/v8/commands/npm-adduser)(aliases: `adduser`) command.
+
+(To specify an organization scope, pass the `--scope` flag.)
 
 ```
 npm login
 
-npm login --scope@OWENER
+npm login --scope@ccdl
 ```
 
-<br />
+<br/>
 
 **2 )** Follow the prompt and enter the username, password, email address, and a one-time password respectively.
 
-The one-time password will either be sent to the registered email address or can be generated if [2FA](https://docs.npmjs.com/configuring-two-factor-authentication) is configured.
-
-e.g.) In our case, we configure [2FA](https://docs.npmjs.com/accessing-npm-using-2fa) with [YubiKey](https://www.yubico.com)
-
-After entering the valid username and email address, the npm CLI will output a URL with a ramdom hash:
+After entering the valid username and email address, the npm CLI outputs a URL with a ramdom hash:
 
 ```
 npm notice Open https://www.npmjs.com/login/xxxxxxx to use your security key for authentication
-Enter one-time password:
 ```
 
-We can access the URL via a browser and follow the web interface to generate a one-time password using the [YubiKey](https://www.yubico.com) device.
+Since we configured [2FA](https://docs.npmjs.com/configuring-two-factor-authentication) with [YubiKey](https://www.yubico.com), we'll neeed to [generate a one-time password](https://docs.npmjs.com/accessing-npm-using-2fa) using the npm Web interface.
 
-<br />
+Access the URL via a browser and follow the web interface to generate a one-time password using the [YubiKey](https://www.yubico.com) device.
 
-**3 )** Upon successful login, the stdin outputs a message as follows:
+Once done, enter it into the prompt:
+
+```
+Enter one-time password: ONE-TIME-PASSWORD
+```
+
+<br/>
+
+**3 )** Upon successful login, it outputs a message to stdout as follows:
 
 ```
 Logged in as USERNAME on https://registry.npmjs.org/.
 ```
 
-**NOTE:** By running [`npm login`](https://docs.npmjs.com/cli/v8/commands/npm-adduser), it will either auto-generate a **per-user .npmrc** with the registry and a temporary access token(whose value differs at each login) or write that information to an exsisting one(npm will also auto-generate an access token in the portal at [npmjs](https://www.npmjs.com)).
+#### &#10074; Check Username
 
-  <br />  
-    
-  **&#10074; Logout from npm**
-  
-  The [`logout`](https://docs.npmjs.com/cli/v7/commands/npm-logout) command logouts without outputting any message to stdout. 
-  ```
-  npm logout 
-  
-  npm logout --scope=@OWENER
-  ```     
-  
-**NOTE:** By running [`npm logout`](https://docs.npmjs.com/cli/v8/commands/npm-logout), it will automatically remove a **per-user .npmrc**(if no other settings were added in that file) or delete the auto-generated line from the existing one(npm will also remove the auto-generated access token from the portal at [npmjs](https://www.npmjs.com)).     
-    
-<br />
-
-**&#10074; Display the current user**
-
-We can check the currently logged-in username with the [`whoami`](https://docs.npmjs.com/cli/v8/commands/npm-whoami) command:
+To display the currently logged-in username, use the [`npm whoami`](https://docs.npmjs.com/cli/v8/commands/npm-whoami) command:
 
 ```
 npm whoami
 ```
 
+#### &#10074; Logout
+
+The [`npm logout`](https://docs.npmjs.com/cli/v7/commands/npm-logout) command logouts without writting any message to stdout.
+
+```
+npm logout
+npm logout --scope=@ccdl
+```
+
+### &#10103; Register a Local Package to npm
+
+#### &#10074; Publish
+
+To publish a local package, use the [`npm publish`](https://docs.npmjs.com/cli/v8/commands/npm-publish) command.
+
+**NOTE:** By default, an organization scoped package is private; thus use the <code>--access <<strong>public</strong>|restricted></code> flag to explicitly set its access level to public upon publishing.
+
+**1 )** In the root of the local package folder, run the following:
+
+```
+npm publish --access public
+```
+
+Since we configured [2FA](https://docs.npmjs.com/configuring-two-factor-authentication) with [YubiKey](https://www.yubico.com), we'll neeed to [generate a one-time password](https://docs.npmjs.com/accessing-npm-using-2fa) using the npm Web interface(follow the same steps as we did when login to the npm account).
+
+<br />
+
+**2 )** Install the published npm package
+
+Once successfully published , it can be installed by its name as well as will be listed on the CCDL account.
+
+```
+npm install @ccdl/refinebio
+```
+
+#### &#10074; Unpublish
+
+**IMPORTANT:**
+
+> Registry data is immutable, meaning once published, a package cannot change. We do this for reasons of security and stability of the users who depend on those packages. So if you've ever published a package called "bob" at version 1.1.0, no other package can ever be published with that name at that version. This is true even if that package is unpublished.
+
+- Once `package@version` has been published, that combination will be permanently unavailable.
+- Once a npm package has been unpublished, it cannot be undone.
+- Once a npm package is entirely unpublished(inluding all versions), it cannot be published again with any new versions within 24 hours.
+
+(For more infomration: [npm Unpublish Policy](https://docs.npmjs.com/policies/unpublish))
+
+**Unpublish a entire package:**
+
+To unpublish all versions at once, use the [`npm unpublish`](https://docs.npmjs.com/cli/v8/commands/npm-unpublish) command and the `-f`(`--force`) flag.
+
+Since we configured [2FA](https://docs.npmjs.com/configuring-two-factor-authentication) with [YubiKey](https://www.yubico.com), we'll neeed to [generate a one-time password](https://docs.npmjs.com/accessing-npm-using-2fa) using the npm Web interface(follow the same steps as we did when login to the npm account). Alternatively we may also pass a one-time passward using the `--otp=CODE-FROM-AUTH-APP` flag.
+
+```
+npm unpublish ccdl@refinebio -f
+```
+
+**Unpublish a specific version:**
+
+```
+npm unpublish @ccdl/refinebio@0.1.0
+```
+
 ---
 
 </details>
 
 <details>
-<summary><h3>&#10113; Manage npmrc Configuration files</h3></summary>
-
-The [`config`](https://docs.npmjs.com/cli/v8/commands/npm-config) command can be used to edit the contents of [npmrc](https://docs.npmjs.com/cli/v8/configuring-npm/npmrc) files.
-
-**&#10074; List npmrc files**
-
-We can utput the npmrc files using the sub-command [`list`](https://docs.npmjs.com/cli/v8/commands/npm-config#list).
-
-To choose a preferred display format, use the `--l` (ini-formatted list) or `--json`(json format) flag:
-
-```
-npm config list -l
-```
-
-<details>
-<summary><strong>per-project .npmcr</strong></summary>
-
-A [per-project .npmrc](https://docs.npmjs.com/cli/v8/configuring-npm/npmrc#per-project-config-file) file must be created in the root of a project.
-
-We can;
-
-- manually create a local .npmrc.
-- use the `config` along with the <code>--location <global|user|<strong>project</strong>></code> flag to open and edit the local .npmrc.
-
-**&#10074; Open and edit per-project .npmrc**
-
-We can open and edit the configuration file using the sub-command [`edit`](https://docs.npmjs.com/cli/v8/commands/npm-config#edit):
-
-```
-cd path/to/project && npm config edit --location project
-```
-
----
-
-</details>
+<summary><h4>Option 2 &horbar; Using Github Actions workflows</h4></summary><br />
+ 
+**NOTE:** To use [Github Actions](https://github.com/features/actions), our local package must be hosted in [Github](https://github.com/).  
   
-<details>
-<summary><strong>per-user .npmcr</strong></summary>
-  
-By default, the sub-command [`edit`](https://docs.npmjs.com/cli/v8/commands/npm-config#edit) opens a [per-user .npmrc](https://docs.npmjs.com/cli/v8/configuring-npm/npmrc#per-user-config-file).
+### &#10102; Setup Authentication
+#### 1 ) Generate an npm access token
+An npm access token must be provided to Github for authentication and it may be created using the [web](https://docs.npmjs.com/creating-and-viewing-access-tokens) or the [npm CLI](https://docs.npmjs.com/creating-and-viewing-access-tokens#creating-tokens-with-the-cli).
 
-**&#10074; Open and edit ~/.npmrc**
+While generating the token;
+
+- be sure to select the type of access token as "**Automation**"
+- save the token value(only visible at the time of creation)
+
+In our case, name it as `GITHUB_AUTOMATION`.
+
+#### 2 ) Add the npm access token to Github secrets
+
+Using the [web](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository), add a new secret and set its value to the npm access token we generated.
+
+Upon creating a new secret, make sure to;
+
+- follow the [naming rules](https://docs.github.com/en/actions/security-guides/encrypted-secrets#naming-your-secrets).
+- prefix with **`NPM_`** as its common naming convention.
+
+In our case, name it as `NPM_TOKEN`.
+
+### &#10103; Setup Github Actions workflows
+
+#### 1 ) Add a workflow directory and file
+
+Github Ations workflows use [YAML](https://learnxinyminutes.com/docs/yaml) syntax to define a [workflow configuration](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions). In the root of our local repository, create a `.github/workflows/NAME-OF-WORKFLOW.yml`.
+
+- `NAME-OF-WORKFLOW` - a name of the workflow and should be self-explanatory
+
+In our case, name it as `publish.yml` as below:
 
 ```
-npm config edit
+package.json
+node_modules/
+.github/
+  workflows/
+    publish.yml
+```
+
+#### 2 ) Configure a workflow
+
+We may configure [workflow triggers](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow) using any supported [events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows).
+
+- The [**`name`**](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#name) property is used to deifne the name of a workflow which will be displayed in our Github repository's [actions page](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions#viewing-the-activity-for-a-workflow-run).
+- The [**`on`**](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on) property is used to define the event. In our case, we use the [`release`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) event to trigger a workflow to automatically publish the package when we [create a new release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) in our Github repository. With that, the `Activity types` of the [`release`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) event should be set to `created`.
+- The [**`jobs`**](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobs) property is used to define tasks to run when the workflow is triggered. In a workflow, we can add any number of jobs which run in parallel. A [unique identifier](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_id) is assigned to each job and each job runs in a separate new instance of the virtual enviromnent specified by [`runs-on`](https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job).
+- The [**`steps`**](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) property is used to define a set of tasks to run in a job. Any number of steps can be added in a single job and those steps are excecuted in the order in which they are defined. A step can [run commands](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun) using the operating system's shell and can [use an action](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses). We may also assign a [`name`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) to each step to display in the [actions page](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions#viewing-the-activity-for-a-workflow-run).
+
+The below workflow publishes our local package to the [public npm registry](https://docs.npmjs.com/about-the-public-npm-registry) upon a new release if [CI tests](https://docs.github.com/en/actions/automating-builds-and-tests/about-continuous-integration) passes.
+
+**publish.yml:**
+
+```yaml
+name: Publish npm package to npmjs
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Clean install dependencies
+        run: rm -rf node_modules/ && yarn install --frozen-lockfile
+      - name: Publish the package
+        run: yarn npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+```
+
+### &#10104; Setup Github Release
+
+#### 1 ) Create a tag for our local package release
+
+> A Git tag is similar to a [Git reference](https://docs.github.com/en/rest/git/refs), but the Git commit that it points to never changes. Git tags are helpful when you want to point to specific releases.
+
+Every [`release`](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) is associated with its corresponding [tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging); that is, generally its [version number](https://semver.org).
+
+There are two types of tags supported in Github:
+|type||
+|:--:|---|
+|Lightweight| It is simply a pointer to a specific commit, is commonly used as a "bookmark" and as private.|
+|Annotated| It is stored as a full object in the Git database, contains additonal meta data(a tagger name, email, and date; can have a tagging message etc), and is commonly used for a public release of a project.|
+
+**NOTE:** It’s generally recommended to create annotated tags so that we have all the information.
+
+<br />
+
+**&#10074; Create an annotated tag**
+
+In the root of our local repository, use the [`git tag -a <tagname> -m <msg>`](https://git-scm.com/docs/git-tag) command to create an annotated tag.
+
+(by passing the flag [`-a`](https://git-scm.com/docs/git-tag#Documentation/git-tag.txt--a) or [`--annotate`](https://git-scm.com/docs/git-tag#Documentation/git-tag.txt--a) makes an unsigned annotated tag object)
+
+e.g.) Creates an annotated tag named as `v1.0.0` with the message "refinebio Release Version 1.0.0"
+
+```
+git tag -a v1.0.0 -m "refinebio Release Version 1.0.0"
+```
+
+It tags the last commit in our local commit history.
+
+<br />
+
+**&#10074; Show tag data**
+
+To see the tag data along with the commit that was tagged, use the [`git show <tagname>`](https://git-scm.com/docs/git-show) command:
+
+```
+git show v1.0.0
 ```
 
 <br />
-  
-**&#10074; Set the value of a key**
-  
-We can assign the value of a key using the sub-command [`set`](https://docs.npmjs.com/cli/v8/commands/npm-config#set).
-  
-e.g.) Set a value of [`init-license`](https://docs.npmjs.com/cli/v8/using-npm/config#init-license)    
+
+**&#10074; List tags**
+
+The following command lists all the tags stored in our repository:
+
 ```
-npm config set init-license "MIT" 
+git tag
 ```
 
 <br />
-  
-**&#10074; Get the value of a key**
 
-We can display the value of a key using the sub-command [`get`](https://docs.npmjs.com/cli/v8/commands/npm-config#get).
+**&#10074; Share a tag with remote**
 
-e.g.) Display the value of `init-author-name`(https://docs.npmjs.com/cli/v8/using-npm/config#init-author-name)
+To share a tag in the local repository, we must explicitly push it the remote repository using the [`git push origin <tagname>`](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_sharing_tags) command:
 
 ```
-npm config get init-author-name
+git push origin v1.0.0
 ```
 
-**NOTE:** In case a project has already been initialized, delete the existing package.json and re-generate a new one to see new changes.
+To push all the local tags to the remote at once, use the `--tags` flag which will transfer all tags that are not already there:
+
+```
+git push origin --tags
+```
+
+<br />
+
+**&#10074; Delete a tag**
+
+To delete a tag in the local repository, use the [`git tag -d <tagname>`](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_deleting_tags) command:
+
+```
+git tag -d v1.0.0
+```
+
+To delete a tag in the remote repository, run the `git push <remote> :refs/tags/<tagname>` command:
+
+(It pushes the null value to the remote tag name that results in the deletion of that tag.)
+
+```
+git push origin :refs/tags/v1.0.0
+```
+
+Or run the `git push origin -d <tagname>` command:
+
+```
+git push origin -d v1.0.0
+```
+
+#### 2 ) Create a release to trigger the publish workflow
+
+Now we can [create a new release ](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release)in the Github repository. It'll instantly trigger the publish workflow and register our local package to the [public npm registory](https://docs.npmjs.com/about-the-public-npm-registry).
+
+Once the publish workflow passes in the [actions page](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions#viewing-the-activity-for-a-workflow-run), [sign in](https://www.npmjs.com) to our CCDL npm account. We will see that this newly registered package is publicly available for installation.
+
+</details>
+
+<p align="right">(<a href="#top">back to top</a>)</p>
 
 ---
 
-</details>
+## Step 3: Manage a npm Package
+
+**(Basic Terminologies)**
+
+ <details>
+<summary>&horbar; Changelog</summary>
   
-<details>
-<summary><strong>global npmcr</strong></summary><br />
-  
-A global configuration will be overwitten by a [per-user .npmrc](https://docs.npmjs.com/cli/v8/configuring-npm/npmrc#per-user-config-file) file.
+> A changelog is a log or record of all notable changes made to a project...and the changelog usually includes records of changes such as bug fixes, new features, etc.
 
-To edit a [global npmrc](https://docs.npmjs.com/cli/v8/configuring-npm/npmrc#global-config-file) file, use the `--global`, `-g`, or <code>--location <global|user|<strong>project</strong>></code> flag.
+It is important to create a [changlog](https://en.wikipedia.org/wiki/Changelog) so that other users and contributors can easily follow what has been updated with a new release. The content should be a human-readable format in chronological order.
 
-**&#10074; Open and edit global npmrc**
+There are several ways to approach this which includes adding a `CHANGELOG.md` file to record new changes and generating a changelog from git commit history either manually or using Github Actions workflows.
 
-```
-npm config -g edit
-```
+(For more information: [Keep a changelog](https://keepachangelog.com/en/1.0.0))
 
-</details>
-
-(For more information: [config](https://docs.npmjs.com/cli/v8/using-npm/config) or view the manual via Terminal, run `npm help config`)
-
-</details>
-
-<details>
-<summary><h3>&#10114; Test a npm Package Locally</h3></summary>
-  
+</details> 
+ 
+### &#10102; Test a npm Package Locally
 It's important to test a npm package during the development phase and **before publishing it to the [public npm registry](https://docs.npmjs.com/about-the-public-npm-registry)**. 
   
 There are several ways to test our packages locally:
   
 <details>
-<summary><strong>Option 1 &horbar; Symbolic linking a npm package</strong></summary>
- 
-<br />
+<summary><strong>Option 1 &horbar; Symbolic linking a npm package</strong></summary><br />
   
 **&#10074; Linking a package**
   
@@ -860,7 +791,7 @@ npm uninstall
 </details>  
   
 <details>
-<summary><strong>Option 2 &horbar; Packing a npm package</strong></summary>
+<summary><strong>Option 2 &horbar; Packing a npm package</strong></summary><br/>
   
 Before publising a locally developed npm package to the [public npm registry](https://docs.npmjs.com/about-the-public-npm-registry)**, we can test it using the [`pack`](https://docs.npmjs.com/cli/v6/commands/npm-pack) command. 
   
@@ -895,7 +826,7 @@ It installs the local package using this tarball and add it to the `node_modules
 </details>    
     
 <details>
-<summary><strong>Option 3 &horbar; Using workspaces</strong></summary>
+<summary><strong>Option 3 &horbar; Using workspaces</strong></summary><br/>
   
 By defining the [`workspaces`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#workspaces) in package.json, we can manage multiple linked packages from the local file system without manually using `npm link` to create and reference each symbolic link of packages.
   
@@ -963,227 +894,86 @@ It runs the tests defined in both `a/package.json` and `b/package.json`.
 
 (For more information: [Workspaces](https://docs.npmjs.com/cli/v8/using-npm/workspaces))
 
-</details>          
-</details>
+</details> 
+ 
+### &#10103; Release a new version 
+> When you make significant changes to a published package, we recommend updating the version number to communicate the extent of the changes to others who rely on your code.
 
-<p align="right">(<a href="#top">back to top</a>)</p>
-
----
-
-## Step &#10124; Publishing a Package to npm Registory
+**NOTE:** Updating the version number will add a tag with the updated release number to the linked git repository.
 
 <details>
 <summary><h4>Option 1 &horbar; Using command line</h4></summary>
   
-By using the [`npm publish`](https://docs.npmjs.com/cli/v8/commands/npm-publish) command, we can publish a local package. By default, an organization scoped package is private, thus we need to use the <code>--access <<strong>public</strong>|restricted></code> flag to explicitly set its access level to public upon publishing.
-  
-**IMPORTANT:** Before publisihg, make sure the local package is well tested and configured correctly. 
-  
-Navigate to the local package directory and run the following:
+:link: [Updating your published package version number](https://docs.npmjs.com/updating-your-published-package-version-number)
+ 
+**IMPORTANT:** Before the new relase, make sure to include a `CHANGELOG.md` in the package root directory.
+
+To update the version number in `package.json`, use the [`npm version`](https://docs.npmjs.com/cli/v8/commands/npm-version) command.
+
+**1 )** Navigate to the package root directory and run the [`npm version <update_type>`](https://docs.npmjs.com/cli/v8/commands/npm-version).
+
+- `<update_type>` should be one of the [SemVar](https://semver.org/) release types
+
+e.g.) Update the version number as the patch type(`0.0.1` to `0.0.2`)
+
+```
+npm version patch
+```
+
+<br />
+ 
+**2 )** Publish the new relase number to the npm registry
+
 ```
 npm publish --access public
 ```
-  
-Once it's published succressfully, it can be installed by its name:
-  
-```
-npm install @OWNER/PACKAGE-NAME  
-```  
+
+<br />
+ 
+**3 )** Login to the CCDL account and confirm the version update
+
+Visit the package page to make sure that the package version number is updated correctly.
+
 ---
-  
+
 </details>
-  
-  
+ 
 <details>
-<summary><h4>Option 2 &horbar; Using Github Actions</h4></summary>
-  
-To use [Github Actions](https://github.com/features/actions), our npm package must be hosted in Github. 
-  
-(Skip [&#10112; Setup Github Repositories]() if they already exist.)  
-  
-<details>
-<summary><h3>&#10112; Setup Github Repositories</h3></summary>
-  
- **1 ) Initialize a local git repository**
-  
- Navigate to the root of the local package and run the [`git init`](https://git-scm.com/docs/git-init) command:   
- ```
- git init
- ```  
-  
-<br />
-  
-**2 ) Create a Github repository for the local package**
-  
-We can manually create a new Github repository via the web interface or use the [`gh repo create`](https://cli.github.com/manual/gh_repo_create) command([install Github CLI](https://github.com/cli/cli#installation)).  
-  
-**&#10074; Create a new repository with Github CLI**
-  
-To create a remote repository in;  
-- interactive mode, pass no arguments.
-- non-interactive mode, pass the repository name and one of the `--public`, `--private`, or `--internal` flags. 
-  
-To add the remote repository to the local repository, pass the `--source <string>` flag.
-
-- `REPOSITORY-NAME` - a name of the npm package without the organization scope
-- `PATH-TO-LOCAL-REPO` - a path to the local repository(i.e. `.` in this case)
-
-```
-hg repo create REPOSITORY-NAME --private --source PATH-TO-LOCAL-REPO
-```
-
-<br />
-  
-**3 ) Push the local files to Github repository** 
-  
-Once the Github repository has been created, add a [.gitignore](https://git-scm.com/docs/gitignore) and commit our local files, then push them to this remote.
-  
----  
-</details> 
-  
-<details>
-<summary><h3>&#10113; Setup Github Actions workflows</h3></summary>
-  
-**Resources:**
-  
-:link: [Github Marketplace](https://github.com/marketplace)   
-:link: [Using workflows](https://docs.github.com/en/actions/using-workflows)  
-      
-  
+<summary><h4>Option 2 &horbar; Using Github Actions workflows</h4></summary>
+ 
 **(Basic Terminologies)**
-
 <details>
-<summary>&horbar; YMAL</summary>
-
-> [YAML](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) is a human-friendly data serialization language for all programming languages.
-
-Github Ations workflows use YAML syntax to define a workflow configuration.
-
-- A YAML file extension is either **.yml** or **.yaml**.
-- Workflow files are stored in `.github/workflows` directory of a Github repository.
-
-(For more information: [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions), [Metadata syntax for GitHub Actions](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions))
-
----
-
-</details>    
-  
-**1 ) Generate the npm Auth Token** 
-  
-We need to create our custom access token to privde Github temporary access to our npm packages. To create an access token is fairly simple and can be done using the web interface or the npm CLI.
-  
-Upon the token generation, make sure to;  
-- choose the access token type as **publish**  
-- copy the token value(only visible at the time of creation)  
-  
-<details>
-<summary><strong>Option 1 &horbar; Using Web Interface</strong></summary>
- 
-- [Creating tokens on the website](https://docs.npmjs.com/creating-and-viewing-access-tokens) 
-  
-- [Viewing tokens on the website](https://docs.npmjs.com/creating-and-viewing-access-tokens#viewing-tokens-on-the-website)
-
----
-
-</details>  
- 
-<details>
-<summary><strong>Option 2 &horbar; Using command line</strong></summary>
- 
-- [Creating tokens on the website](https://docs.npmjs.com/creating-and-viewing-access-tokens)
-
-- [Viewing tokens on the website](https://docs.npmjs.com/creating-and-viewing-access-tokens#viewing-tokens-on-the-website)
-
----
-
-</details>    
-  
-<br/>  
-  
-**2 ) Store the npm Auth Token in Github**
-
-:link: [Creating and using encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)
-
-Add a new [secret](<[https://docs.github.com/en/rest/actions/secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#about-encrypted-secrets)>) in Github and assign the value of the newly generated npm token. It's easy to generate a new token using the web interface.
-
-Upon creating a new secret, make sure to;
-
-- follow the [naming rules](https://docs.github.com/en/actions/security-guides/encrypted-secrets#naming-your-secrets)
-- prefix with **NPM\_**(e.g. NPM_TOKEN, NPM_AUTH_TOKEN) as its general naming convention.
-
-<br/>  
-  
-**3 ) Create a workflow file in the Github repository**   
-  
-In the root of the local package folder, create a `.github/workflows/NAME-OF-WORKFLOW.yml` file.
-  
-- `NAME-OF-WORKFLOW` - a name of the workflow(e.g. publish, push, etc)
-  
+<summary>&horbar; Conventional Commits</summary>
+    
+> The [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification) is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of.
+    
+Utilizing Conventional Commits not only improves communication and understanding regarding the context of each commit, but it also alllows us to easily generate release notes using automated tooling systems. It's specification is based on the [Angular Commit Guidelines](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines).    
+    
+<br />
+    
+**&#10074; Message Structure Format**
 ```
-package.json  
-node_modules/  
-.github/
-  workflows/
-    publish.yml
+<type>[optional scope]: <description>
+[optional body]
+[optional footer(s)] 
 ```    
-  
-<br/>
-  
-**4 ) Configure a workflow**    
-  
-We can configure Github Actions workflows to publish the npm package on each new release.
-  
-**&#10074; Creating a new release**  
-  
-:link: [Releasing Projects on Github](https://docs.github.com/en/repositories/releasing-projects-on-github)
-
-> A Git tag is similar to a [Git reference](https://docs.github.com/en/rest/git/refs), but the Git commit that it points to never changes. Git tags are helpful when you want to point to specific releases. These endpoints allow you to read and write [tag objects](https://git-scm.com/book/en/v2/Git-Internals-Git-References#Tags) to your Git database on GitHub. The Git tags API only supports annotated [tag objects](https://git-scm.com/book/en/v2/Git-Internals-Git-References#Tags), not lightweight tags.
-
-A new relase can be created manually using the web interface, or setup a workflow to automatically create a new release upon [tagging](https://git-scm.com/book/en/v2/Git-Basics-Tagging) prefixed with **v**, for instance(see [Step &#10125; Managing a npm Package with Github Actions]()).
-
-<br/>  
-   
-**&#10074; Publishing a npm package**
-  
-:link: [Publishing packages to the npm registry](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry)  
-  
-To trigger a workflow upon creation of release in Github repository, use the [`release`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) event and its `Ativity types` set as `created`. Events can be defined in [**`on`**](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on) property. In a workflow, we can run any number of [**`jobs`**](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobs) which run in parallel, as well as we can define any number of [**`steps`**](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsteps) to be included in each job.
  
-e.g.) Publishes a package to the [public npm registry](https://docs.npmjs.com/about-the-public-npm-registry) if [CI tests](https://docs.github.com/en/actions/automating-builds-and-tests/about-continuous-integration) pass.    
-  
-**publish.yml:**  
-```yaml
-name: Publish npm package to npmjs
-on:
-  release:
-    types: [created]
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Clean install dependencies
-        run: rm -rf node_modules/ && yarn install --frozen-lockfile
-      - name: Publish the package
-        run: yarn npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-```
-
-</details>  
-</details>  
-  
-<p align="right">(<a href="#top">back to top</a>)</p>
-  
----
-  
-## Step &#10125; Managing a npm Package with Github Actions
-
-Automatic relasing, versioning, runner, other tests etc  
+<br />
+    
+**&#10074; Necessary Structural Elements**
+ 
+|Type|Definition|[SemVar](https://semver.org/#summary)<br/> <sup>(equivalent)</sup>| 
+|:---:|---|:---:|
+|fix|A commit that patches a bug and is backwards compatible|`PATCH`| 
+|feat|A commit that introduces a new feature is backwards compatible|`MINOR`| 
+|BREAKING CHANGE|A commit that introduces a breaking API change and;<br/>- has a footer `BREAKING CHANGE:` or<br/>- appends a `!` after the type/scope|`MINOR`| 
+|others|- Based on the the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines), `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:` etc are allowed<br/>- Footers other than `BREAKING CHANGE: < description >` may be provided and follow a convention similar to [git trailer format](https://git-scm.com/docs/git-interpret-trailers)<br/>- A scope may be provided after a type for additional contextual information and is contained within parenthesis(e.g. `feat**(**parser**)**: add ability to parse arrays`)|Depends on the context|  
+   
+(For more information: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0))     
+ 
+--- 
+</details> 
+ 
 (in progress)
-
+</details> 
 <p align="right">(<a href="#top">back to top</a>)</p>


### PR DESCRIPTION
## Issue Number
#22

Parent issue:  #21

## Purpose/Implementation Notes
Track the requirements to publish the package on NPM.
- Links to the resource docs to determine which approaches are most appropriate to keep in `publish.md`(specific to refinebio-js)

## Types of changes
- Created a temporary directory `docs` to store the documentation files
   - e.g.) `src/docs/requirements-to-publish.md`

## Functional tests
N/A

## Checklist
- [x] Lint and unit tests pass locally with my changes

## Screenshots
N/A

## Note

This is a 1st draft for the general instruction for publishing a npm package with Github Packages Registry(found to be a more robust approach than directly publishing the package to the npm Registry)

Benefits: 
- Offers both public/private registries without the need of third party tools or paid services
- Offers the Github Actions without extra configurations as well as support other CI tools
- Offers built-in Package Analysis
- Supports a various registry protocols including the npm and the personal access token can be used for authentication 
- Utilizes the Github global CDN for fast performance

Please see the [GitHub Packages](https://github.com/features/packages) for more information. Thank you.
