### PR TITLE
add mergeConfig helper in utils

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import defaultConfig from 'config'
-import { deepCopy } from 'utils/deepCopy'
+import { mergeConfig } from 'utils/mergeConfig'
 import { compendia } from 'resources/compendia'
 import { computationalResults } from 'resources/computationalResults'
 import { computedFiles } from 'resources/computedFiles'
@@ -41,10 +41,10 @@ export {
 }
 
 export default (override = {}) => {
-  const config = { ...deepCopy(defaultConfig), ...deepCopy(override) }
+  const config = mergeConfig(defaultConfig, override)
 
   return {
-    updateConfig: (changes) => ({ ...deepCopy(config), ...deepCopy(changes) }),
+    updateConfig: (changes) => mergeConfig(config, changes),
     compendia: compendia(config),
     computationalResults: computationalResults(config),
     computedFiles: computedFiles(config),

--- a/src/utils/mergeConfig.js
+++ b/src/utils/mergeConfig.js
@@ -1,0 +1,16 @@
+import { deepCopy } from 'utils/deepCopy'
+
+/*
+@name mergeConfig 
+@description overwrite the config with a new configuration setting
+@param {object} changes - a new configration setting
+@param {object} source - the current config 
+@return {object} (TEMP): returns a shallow-merged and deep-copied updated config 
+*/
+
+export const mergeConfig = (source, changes) => ({
+  ...deepCopy(source),
+  ...deepCopy(changes)
+})
+
+export default mergeConfig


### PR DESCRIPTION
## Issue Number
#27 

## Purpose/Implementation Notes
Added `util/mergeConfig `that uses `deepCopy` to merge them. And use it in `api/index.js`
(NOTE: currently it returns a shallow-merged and deep-copied updated config)

## Types of changes
- New feature (non-breaking change which adds functionality)

## Functional tests
N/A

## Checklist
- [x] Lint and unit tests pass locally with my changes

## Screenshots
N/A