### PR TITLE
26 - Automate Publishing with Github Actions

### DIFF
--- a/auto-publish.md
+++ b/auto-publish.md
@@ -57,14 +57,15 @@ To setup a package.json for an npm package, the following fields should be inclu
     "url": "https://github.com/AlexsLemonade/refinebio-js.git"
   },
   "keywords": ["refinebio", "refinebio-js", "refinebo JS client"],
+  "author": "CCDL <contact@ccdatalab.org>",
   "contributors": [
     {
-      "name": "davidsmejia",
-      "email": "...@ccdatalab.org"
+      "name": "David Mejia",
+      "email": "david@ccdatalab.org"
     },
     {
-      "name": "nozomione",
-      "email": "...@ccdatalab.org"
+      "name": "Nozomi Ichihara",
+      "email": "nozomi@ccdatalab.org"
     }
   ],
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## Issue Number
#26 

## Purpose/Implementation Notes
- Created `auto-publish.md` which contains Step-by-Step instructions for publishing the refinebio npm package with Github Actions
- Added this file to the root directory
- Locally tested the auto-publish workflow