### PR TITLE
34 - Manual Deploy v0.0.1

### DIFF
--- a/NOTE.md
+++ b/NOTE.md
@@ -1,9 +1,0 @@
-### Update
-
-The refinebio v0.0.1 has been manually published to the public npm registry under the CCDL organization scope and now publicly available for installation.
-
-- It was published using the`publish.md`(#29) Step-by-Step instruction.
-- The `package.json` was updated for this release and merged into `dev` and `main`
-- It can be unpublished at any time, except that the same `package@version` combination won't be available(the npm registry data is immutable)
-
-**NOTE:** I sent a new invitation to your account, please accept it upon return(the old one expired). It also requires for you to setup 2FA(enforced by the CCDL account). Once it's approved, your name will show up in the `Collaborators` under the CCDL package page.


### PR DESCRIPTION
## Issue Number

#34 

## Purpose/Implementation Notes
The refinebio `v0.0.1` has been manually published to the public npm registry under the CCDL organization scope and now publicly available for installation.

- It was published using the`publish.md`(#29) Step-by-Step instruction.
- The `package.json` has been updated for this release and merged into `dev` and `main`.
- This release can be unpublished at any time, except that the same `package@version` combination won't be available(the npm registry data is immutable).

**NOTE:** I sent a new invitation to your account, please accept it upon return(the old one expired). It also requires for you to setup 2FA(enforced by the CCDL account). Once it's approved, your name will show up in the `Collaborators` under the CCDL package page. Thank you, David!

(I made a tiny update to the `README.md` file since I couldn't make a new PR without modifying codebase.)